### PR TITLE
Credentials for local env patch

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,10 @@ NODE_ENV=development
 TOKEN_SECRET=jqowd0qwe012jjje21dojdol2io1dj12o
 
 # db
-DB_HOST=ignore
-DB_PORT=ignore
-DB_PASSWORD=ignore
-DB_USER=ignore
+DB_HOST=
+DB_PORT=
+DB_PASSWORD=
+DB_USER=
 
 # github
 GITHUB_CLIENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 .env
 .vscode
 .deployment
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -7,5 +7,6 @@ https://github.com/benawad/vscode-stories
 1. Have PostgreSQL running on your computer
 2. Create a database called `stories`
 3. Copy `.env.example` to `.env` and fill in `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` (you will have to register a GitHub OAuth account and set the callback url to: http://localhost:8080/auth/github/callback)
-4. Don't forget to run `yarn`
-5. `yarn dev` to startup server
+4. Fill in database credentials to `.env` ([typeorm docs options](https://typeorm.io/#/connection-options/postgres--cockroachdb-connection-options))
+5. Don't forget to run `yarn`
+6. `yarn dev` to startup server

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,14 +25,13 @@ const upgradeMessage =
   "Upgrade the VSCode Stories extension, I fixed it and changed the API.";
 
 const main = async () => {
-  const prodCredentials = __prod__
-    ? {
+  const credentials = 
+    {
         host: process.env.DB_HOST,
         port: Number(process.env.DB_PORT),
         username: process.env.DB_USER,
         password: process.env.DB_PASSWORD,
-      }
-    : {};
+    };
   console.log("about to connect to db, host: ", process.env.DB_HOST);
 
   const conn = await createConnection({
@@ -42,7 +41,7 @@ const main = async () => {
     migrations: [join(__dirname, "./migrations/*")],
     // synchronize: !__prod__,
     logging: !__prod__,
-    ...prodCredentials,
+    ...credentials,
   });
   console.log("connected, running migrations now");
   await conn.runMigrations();


### PR DESCRIPTION
A small change to allow different credentials used on local environment. I've added package-lock.json to .gitignore to avoid cluttering next to yarn files.

- Updated readme
- Deleted ignore from .env.example to avoid confusion
- updated index.ts variable