### PR TITLE
[Feature] user specifc stories endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import { TextStory } from "./entities/TextStory";
 import { User } from "./entities/User";
 import { isAuth } from "./isAuth";
 import { Octokit } from "@octokit/rest";
-import { fetchStories } from "./queryBuilder";
+import { fetchStories, fetchUserStories } from "./queryBuilder";
 const octokit = new Octokit();
 
 const upgradeMessage =
@@ -126,6 +126,25 @@ const main = async () => {
         `select u."username" from "user" u where u."id" = '${req.userId}';`
       )
     );
+  });
+
+  app.get("/user/text-stories/:cursor?", isAuth(), async (req: any, res) => {
+    let cursor = 0;
+    if (req.params.cursor) {
+      const nCursor = parseInt(req.params.cursor);
+      if (!Number.isNaN(nCursor)) {
+        cursor = nCursor;
+      }
+    }
+    const limit = 10;
+
+    const stories = await fetchUserStories(limit, cursor, req.userId);
+
+    const data = {
+      stories: stories.slice(0, limit),
+      hasMore: stories.length === limit + 1,
+    };
+    res.json(data);
   });
 
   app.get("/text-stories/friends/hot/:cursor?/:friendIds?", isAuth(), async (req: any, res) => {

--- a/src/queryBuilder.ts
+++ b/src/queryBuilder.ts
@@ -25,3 +25,29 @@ export async function fetchStories(
 
     return stories;
 }
+
+export async function fetchUserStories(
+  limit: number,
+  cursor: number,
+  userId: string
+) {
+  const queryString = `
+    select
+    ts.id,
+    ts."creatorId",
+    u.username "creatorUsername",
+    u."id" "creatorId",
+    u."photoUrl" "creatorAvatarUrl",
+    u.flair
+    from text_story ts
+    inner join "user" u on u.id = ts."creatorId"
+    where u.id = '${userId}'
+    order by (ts."numLikes"+1) / power(EXTRACT(EPOCH FROM current_timestamp-ts."createdAt")/3600,1.8) DESC
+    limit ${limit + 1}
+    ${cursor ? `offset ${limit * cursor}` : ""}
+  `;
+  
+  const stories = await getConnection().query(queryString);
+
+  return stories;
+}


### PR DESCRIPTION
## Description

Added an endpoint, which returns the latest ten stories that got recorded by the authenticated user.
If there are more than ten in the DB, the frontend will put a cursor in the path.

## Motivation and Context

The normal stories, which get loaded contain the latest 21 stories that got recorded. The authenticated user might want to see their own stories without searching for each one. This PR will make it easier for authenticated users to have clear overview of their own stories.

## How Has This Been Tested?

### Database Test

First, I tested the query in my local DB with cursor set to zero and hard coded my userId. Current number of stories from this user in the DB: one.
![image](https://user-images.githubusercontent.com/34520811/105645285-f1d25500-5e9a-11eb-8be7-e11b90ceac89.png)

### Postman Test

Secondly, I tested by using Postman. I changed the limit to 1 story, because I didn't wanna make so many stories. I had three stories in my db.
![image](https://user-images.githubusercontent.com/34520811/105645211-6062e300-5e9a-11eb-952c-cbbee55ff011.png)

### VSCode Stories Test

After all, I implemented this endpoint in the frontend to see how it will work there. Everything worked fine.